### PR TITLE
feat: handle subscription deletion in stripe webhook

### DIFF
--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -73,9 +73,21 @@ serve(async (req) => {
             }
 
             // Optional: Handle cancellations or failures
-            case 'customer.subscription.deleted':
-                // Logic to set user status to 'inactive'
+            case 'customer.subscription.deleted': {
+                const subscription = event.data.object as Stripe.Subscription;
+                const customerId = subscription.customer as string;
+
+                if (customerId) {
+                    const { error } = await supabaseAdmin
+                        .from('subscriptions')
+                        .update({ status: 'inactive' })
+                        .eq('stripe_customer_id', customerId);
+
+                    if (error) throw error;
+                    console.log(`Subscription for customer ${customerId} set to inactive.`);
+                }
                 break;
+            }
             default:
                 console.log(`Unhandled event type ${event.type}`);
         }


### PR DESCRIPTION
- Implement logic for `customer.subscription.deleted` event in Stripe webhook.
- Update `subscriptions` table to set status to 'inactive' when a subscription is deleted.
- Use `stripe_customer_id` to identify the user record.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds handling for `customer.subscription.deleted` to mark subscriptions inactive by `stripe_customer_id`.
> 
> - **Stripe webhook (`supabase/functions/stripe-webhook/index.ts`)**:
>   - Handle `customer.subscription.deleted` events by updating `subscriptions` to `status: 'inactive'` where `stripe_customer_id` matches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84720732b7062e2388f523274ee0d6603077ce1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of subscription deletion events to properly update subscription status to inactive and log the operation with error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->